### PR TITLE
bringing in new site header

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -61,10 +61,10 @@ body {
     background-color: #fff;
     font-size: 16px;
     font-family: "Open Sans", Helvetica, Arial, sans-serif;
+    margin: 0;
 }
 .container {
     position: relative;
-    background: #fff;
     max-width: 1140px;
     margin: 2em auto;
     padding-left: 12em;
@@ -107,6 +107,7 @@ header p a {
 }
 
 #schedule-controls {
+    clear: both;
     font-size: .83em;
     margin: 2em auto;
     padding: 0;
@@ -373,6 +374,104 @@ header p a {
 .page-block {
     *zoom: 1;
 }
+
+/* SINKER BODGE JOB */
+
+header {
+  overflow-x: hidden;
+  height: 400px;
+  background-size: 1500px;
+  background-position: 0 0;
+  max-width: 1500px;
+  margin: 0px auto;
+  margin-bottom: 50px;
+  position: relative;
+}
+
+#headertop {
+  width: 100%;
+  height: 70px;
+  background-color:rgba(0, 0, 0, 0.3)
+}
+
+header.postits {
+  background-image: url(http://www.srccon.org/media/img/2015/post-its.jpg);
+}
+
+.container {
+  box-sizing: border-box;
+  display: block;
+  max-width: 1000px;
+  margin: 0px auto;
+  padding: 0px;
+  position: relative;
+}
+
+header a#cornerlogo img {
+  width: 150px;
+  position: absolute;
+  top: 5px;
+}
+
+header nav {
+  float: right;
+  overflow: hidden;
+  font-size: 1.1em;
+  line-height: 1.7em;
+}
+
+header nav ul {
+  padding-left: 0px;
+  text-align: center;
+  margin-bottom: 1em;
+}
+
+header nav ul li {
+  width: auto;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0px 10px;
+  padding-bottom: 5px;
+}
+
+header nav ul li a {
+  color: white;
+  text-decoration: none;
+}
+
+header nav ul li a:hover {
+  color: white;
+  border-bottom: 1px solid white;
+}
+
+#headbox {
+  clear: both;
+  width: 100%;
+  max-width: 660px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  right: 1%;
+  padding-top: 70px;
+}
+
+#headbox h2 {
+  color: white;
+  font-size: 3em;
+  margin-bottom: 10px;
+  margin-top: 0;
+}
+
+#headbox h3 {
+  color: white;
+  font-size: 1.4em;
+  font-weight: 400;
+  margin-top: 0px;
+}
+
+
+/* END SINKER BODGE JOB */
 
 @media only screen and (max-width: 940px) {
     #schedule-controls ul {

--- a/index.html
+++ b/index.html
@@ -21,17 +21,29 @@
         <script src="js/modernizr.js"></script>
     </head>
     <body>
-        <div class="container">
-            <header>
-                <h1><a href="/"><img src="img/srccon_flag.png" alt="SRCCON"> 2015 Schedule</a></h1>
-                <p>
-                    June 25 & 26 &bull; <a href="https://goo.gl/maps/zWoYu">McNamara Alumni Center</a>, Minneapolis, MN &bull; <a href="http://srccon.org">Full SRCCON site</a>
-                </p>
-            </header>
+      <header class="postits">
+        <div id="headertop">
+          <div class="container">
 
-            <article id="schedule"></article>
+              <a href="/" id = "cornerlogo"><img src="http://www.srccon.org/media/img/2015/corner_logo.png"></a>
+
+            <nav class="navigation">
+              <ul>
+      <li id="sessions"><a href="/sessions">sessions</a></li>
+      <li id="logistics"><a href="/logistics">logistics</a></li>
+      <li id="docs"><a href="/docs">docs</a></li>
+      <li id="registration"><a href="/tickets">tickets</a></li>
+    </ul>
+
+            </nav>
+          <div id="headbox">
+
+              <h2>Schedule</h2>
+              <h3>SRCCON is built around two days of peer-led conversations, hands-on workshops, and skillshares.</h3>
+
+          </div>
         </div>
-
+      </div>
 
         <script type="text/template" id="session-list-template">
         <div id="thursday" class="schedule-tab">
@@ -56,7 +68,7 @@
             <h3><span>Thursday 5:30 PM</span></h3>
             <div id="thursday-evening" class="page-block"><div class="open-block">OPEN</div></div>
         </div>
-        
+
         <div id="friday" class="schedule-tab">
             <h3><span>Friday 10 AM</span></h3>
             <div id="friday-morning" class="page-block"><div class="open-block">OPEN</div></div>
@@ -133,7 +145,7 @@
             </div>
         </div>
         </script>
-        
+
         <script src="js/jquery-2.1.0.min.js"></script>
         <script src="js/underscore-min.js"></script>
         <script src="js/marked.min.js"></script>


### PR DESCRIPTION
OK, so this is a rough approximation of the header from the current SRCCON site. I started to hack away at things and then realized I _really shouldn't do that_ since I can't actually get the whole thing to load locally, etc. 

Basic concept is: bring the same basic look/feel of the headers of the srccon site to the schedule app. PROBABLY we will want the header image to be more like 200 px vs 400 px, etc. But I think that generally this should _feel_ like the rest of the site, allow nav access, etc. 

Use these bones & style as you see fit, including dumping them entirely and doing this the smart way.
